### PR TITLE
Change 'roll' to 'role' where appropriate

### DIFF
--- a/content/articles/2017-03-23-automating-python-with-ansible.ipynb
+++ b/content/articles/2017-03-23-automating-python-with-ansible.ipynb
@@ -516,7 +516,7 @@
     "\n",
     "Check out [the docs](http://docs.ansible.com/ansible/playbooks_roles.html#roles) to learn more about role organization.\n",
     "\n",
-    "Here's what our roll looks like:"
+    "Here's what our role looks like:"
    ]
   },
   {
@@ -574,7 +574,7 @@
    "source": [
     "Note that I added `tags:` to the task definitions. [Tags](http://docs.ansible.com/ansible/playbooks_tags.html) just allow you to run a portion of a playbook instead of the whole thing with the `--tags` flag for `ansible-playbook`.\n",
     "\n",
-    "Now that we have the supervisor install encapsulated in a role, we can write a simple playbook to run the roll."
+    "Now that we have the supervisor install encapsulated in a role, we can write a simple playbook to run the role."
    ]
   },
   {
@@ -698,7 +698,7 @@
     "\n",
     "You can search the Galaxy website for [miniconda](https://galaxy.ansible.com/list#/roles?page=1&page_size=10&autocomplete=miniconda) and see that a handful of roles for installing Miniconda exist. I liked [this one](https://galaxy.ansible.com/andrewrothstein/miniconda/). \n",
     "\n",
-    "We can install the roll locally using the `ansible-galaxy` command line tool."
+    "We can install the role locally using the `ansible-galaxy` command line tool."
    ]
   },
   {
@@ -721,7 +721,7 @@
     "editable": true
    },
    "source": [
-    "You can have the roll installed wherever you want (run `ansible-galaxy install --help` to see how, but by default they'll go to `/usr/local/etc/ansible/roles/`. "
+    "You can have the role installed wherever you want (run `ansible-galaxy install --help` to see how, but by default they'll go to `/usr/local/etc/ansible/roles/`. "
    ]
   },
   {
@@ -869,7 +869,7 @@
    "source": [
     "#### Overriding Ansible Variables\n",
     "\n",
-    "Once a roll is installed locally, you can add it to a play just like you can with roles you wrote. Installing Miniconda is now as simple as:\n",
+    "Once a role is installed locally, you can add it to a play just like you can with roles you wrote. Installing Miniconda is now as simple as:\n",
     "\n",
     "```\n",
     "  roles:\n",


### PR DESCRIPTION
Hi Tim, great article, thanks for writing it! Seeing 'roll' repeatedly where I think you meant 'role' was making my eye twitch, so I changed it. Thanks again.